### PR TITLE
color change

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -99,8 +99,8 @@
     .item-buy-btn
       =link_to '購入画面に進む', transaction_items_path(id: @item.id)
   - else
-    .item-buy-btn
-      売り切れです
+    .item-buy-btn-delete
+      売り切れました。
   .item-description
     %p.item-description-inner
       = @item.description


### PR DESCRIPTION
#What
ボタンの色を変えました。
#Why
購入ボタンと売り切れのボタンの色が同じだとわかりにくくて不便だから。